### PR TITLE
using EntryPointNotFoundException instead of ApplicationException

### DIFF
--- a/Pluto.Tests/SyscallTests.cs
+++ b/Pluto.Tests/SyscallTests.cs
@@ -44,7 +44,6 @@ namespace Pluto.Tests
 
                 Assert.False(processHandle.IsInvalid);
             }
-
             else
             {
                 var syscall = new Syscall<Delegates.OpenProcess32>();

--- a/Pluto/PortableExecutable/DataDirectories/ExportDirectory.cs
+++ b/Pluto/PortableExecutable/DataDirectories/ExportDirectory.cs
@@ -20,7 +20,7 @@ namespace Pluto.PortableExecutable.DataDirectories
 
             // Read the export directory
 
-            var exportDirectory = MemoryMarshal.Read<ImageExportDirectory>(ImageBytes.Span.Slice(DirectoryOffset));
+            var exportDirectory = MemoryMarshal.Read<ImageExportDirectory>(ImageBytes.Span[DirectoryOffset..]);
 
             // Read the name address table
 
@@ -42,7 +42,7 @@ namespace Pluto.PortableExecutable.DataDirectories
 
                 var nameOffset = RvaToOffset(nameAddressTable[middle]);
 
-                var nameLength = ImageBytes.Span.Slice(nameOffset).IndexOf(byte.MinValue);
+                var nameLength = ImageBytes.Span[nameOffset..].IndexOf(byte.MinValue);
 
                 var name = Encoding.UTF8.GetString(ImageBytes.Span.Slice(nameOffset, nameLength));
 
@@ -69,7 +69,6 @@ namespace Pluto.PortableExecutable.DataDirectories
                 {
                     high = middle - 1;
                 }
-
                 else
                 {
                     low = middle + 1;

--- a/Pluto/Syscall.cs
+++ b/Pluto/Syscall.cs
@@ -79,7 +79,7 @@ namespace Pluto
 
             if (function is null)
             {
-                throw new ApplicationException($"Failed to find the function {functionName} in the DLL {dllName}");
+                throw new EntryPointNotFoundException($"Failed to find the function {functionName} in the DLL {dllName}");
             }
 
             // Read the syscall index

--- a/Pluto/Syscall.cs
+++ b/Pluto/Syscall.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+
 using Pluto.Assembly;
 using Pluto.Native;
 using Pluto.Native.Enumerations;
@@ -33,7 +34,8 @@ namespace Pluto
                 throw new ArgumentException("The provided delegate was not attributed with the SyscallImport attribute");
             }
 
-            if (!syscallImport.DllName.Equals("ntdll.dll", StringComparison.OrdinalIgnoreCase) && !syscallImport.DllName.Equals("win32u.dll", StringComparison.OrdinalIgnoreCase))
+            if (!syscallImport.DllName.Equals("ntdll.dll", StringComparison.OrdinalIgnoreCase)
+                && !syscallImport.DllName.Equals("win32u.dll", StringComparison.OrdinalIgnoreCase))
             {
                 throw new NotSupportedException("The provided DLL does not export any syscalls");
             }
@@ -47,7 +49,9 @@ namespace Pluto
 
             var syscallIndex = GetSyscallIndex(syscallImport.DllName, syscallImport.FunctionName);
 
-            var shellcodeBytes = Environment.Is64BitProcess ? Assembler.AssembleSyscall64(syscallIndex) : Assembler.AssembleSyscall32(syscallIndex);
+            var shellcodeBytes = Environment.Is64BitProcess
+                ? Assembler.AssembleSyscall64(syscallIndex)
+                : Assembler.AssembleSyscall32(syscallIndex);
 
             // Write the shellcode into the pinned object heap
 
@@ -84,9 +88,12 @@ namespace Pluto
 
             // Read the syscall index
 
-            var functionBytes = dllBytes.AsSpan().Slice(function.Offset);
+            var functionBytes = dllBytes.AsSpan()[function.Offset..];
 
-            return MemoryMarshal.Read<int>(Environment.Is64BitProcess ? functionBytes.Slice(Constants.SyscallIndexOffset64) : functionBytes.Slice(Constants.SyscallIndexOffset32));
+            return MemoryMarshal.Read<int>(
+                Environment.Is64BitProcess
+                ? functionBytes[Constants.SyscallIndexOffset64..]
+                : functionBytes[Constants.SyscallIndexOffset32..]);
         }
     }
 }


### PR DESCRIPTION
The documentation for [ApplicationException](https://docs.microsoft.com/en-us/dotnet/api/system.applicationexception?view=net-5.0#remarks) remarks to not throw or catch any `Exceptions` of this type.

I replaced it with the [EntryPointNotFoundException](https://docs.microsoft.com/en-us/dotnet/api/system.entrypointnotfoundexception?view=net-5.0) I found referenced in [NativeLibrary.GetExport(IntPtr, String)](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativelibrary.getexport?view=net-5.0#exceptions).

Besides that I made some refactoring and started using the `Range-Operator` in [Span<T>.Slice](https://docs.microsoft.com/en-us/dotnet/api/system.span-1.slice?view=net-5.0) Method calls.
